### PR TITLE
Use the Package root  instead of the solution root to find other Nuge…

### DIFF
--- a/NuGet.Packer.targets
+++ b/NuGet.Packer.targets
@@ -44,7 +44,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
 
     <!-- NuGet command -->
-    <NuGetToolsPath>$(SolutionDir)packages\NuGet.CommandLine.3.3.0\tools</NuGetToolsPath>
+    <NugetPackageRoot Condition=" '$(NugetPackageRoot)'=='' ">$(MSBuildThisFileDirectory)..\..\</NugetPackageRoot>
+    <NuGetToolsPath Condition=" '$(NuGetToolsPath)'=='' ">$(NugetPackageRoot)NuGet.CommandLine.3.3.0\tools</NuGetToolsPath>
     <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\NuGet.exe</NuGetExePath>
     <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">&quot;$(NuGetExePath)&quot;</NuGetCommand>
     <NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 &quot;$(NuGetExePath)&quot;</NuGetCommand>


### PR DESCRIPTION
…t Package

It's possible to define an alternate path for the Nuget Packages when using a nuget.config file.
If this is the case, the Nuget Packages might be somewhere else than under the Package folder under the solution.
Using a relative path to the location of the current targets should ensure the path to the Packages is good.
