### PR TITLE
Mark the package as development dependency.

### DIFF
--- a/NuGet.Packer.nuspec
+++ b/NuGet.Packer.nuspec
@@ -11,6 +11,7 @@
     <description>Makes it incredibly easy to generate NuGet packages from any .NET solution, including projects with .nuspec files!</description>
     <copyright>Copyright 2016</copyright>
     <tags>NuGet</tags>
+    <developmentDependency>true</developmentDependency>
     <dependencies>
         <dependency id="NuGet.CommandLine" version="[3.3.0]" />
     </dependencies>


### PR DESCRIPTION
Issue: https://github.com/jchadwick/NuGet.Packer/issues/6

Docs:
http://stackoverflow.com/questions/15012963/dont-include-dependencies-from-packages-config-file-when-creating-nuget-package
http://docs.nuget.org/create/nuspec-reference#Metadata_Section
