### PR TITLE
Update NuGet.CommandLine from 3.3.0 to 3.5.0

### DIFF
--- a/NuGet.Packer.nuspec
+++ b/NuGet.Packer.nuspec
@@ -13,7 +13,7 @@
     <tags>NuGet</tags>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-        <dependency id="NuGet.CommandLine" version="[3.3.0]" />
+        <dependency id="NuGet.CommandLine" version="[3.5.0]" />
     </dependencies>
   </metadata>
   <files>

--- a/NuGet.Packer.targets
+++ b/NuGet.Packer.targets
@@ -45,7 +45,7 @@
 
     <!-- NuGet command -->
     <NugetPackageRoot Condition=" '$(NugetPackageRoot)'=='' ">$(MSBuildThisFileDirectory)..\..\</NugetPackageRoot>
-    <NuGetToolsPath Condition=" '$(NuGetToolsPath)'=='' ">$(NugetPackageRoot)NuGet.CommandLine.3.3.0\tools</NuGetToolsPath>
+    <NuGetToolsPath Condition=" '$(NuGetToolsPath)'=='' ">$(NugetPackageRoot)NuGet.CommandLine.3.5.0\tools</NuGetToolsPath>
     <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\NuGet.exe</NuGetExePath>
     <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">&quot;$(NuGetExePath)&quot;</NuGetCommand>
     <NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 &quot;$(NuGetExePath)&quot;</NuGetCommand>


### PR DESCRIPTION
If a package already defines a System-Reference as a dependency, than package creation fails (e.g.  'Newtonsoft.Json' already has a dependency defined for 'Microsoft.CSharp'). NuGet.CommandLine 3.5.0 fixes this problem